### PR TITLE
Reuse factories to improve performance

### DIFF
--- a/lib/rails/html/owasp/sanitizer.rb
+++ b/lib/rails/html/owasp/sanitizer.rb
@@ -13,12 +13,26 @@ module Rails
 
       class Sanitizer
 
+        def initialize
+          @last_policy_options = nil
+        end
+
         def sanitize(html, options = {})
           return html if html.nil? || html.empty?
-          policy(options).to_factory.sanitize html
+          policy_factory(options).sanitize html
         end
 
         private
+
+        # Use an already-built factory if the options haven't changed
+        # to greatly improve performance
+        def policy_factory(options = {})
+          if @last_policy_options != options.hash
+            @last_policy_options = options.hash
+            @factory = policy(options).to_factory
+          end
+          @factory
+        end
 
         # returns a filtering policy that strips out all tags and encodes any
         # entities.

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -1,5 +1,6 @@
 require "minitest/autorun"
 require "rails-html-sanitizer-jruby"
+require 'benchmark'
 
 class SanitizersTest < Minitest::Test
 
@@ -458,6 +459,16 @@ class SanitizersTest < Minitest::Test
       assert_equal '<a>hello</a>', sanitized
       assert_equal Encoding::UTF_8, sanitized.encoding
     end
+  end
+
+  def test_performance_reusing_sanitizer
+    sanitizer = Rails::Html::Owasp::WhiteListSanitizer.new
+    measurement = Benchmark.measure do
+      10_000.times do
+        sanitizer.sanitize('<a href="http://www.domain.com?var1=1&amp;var2=2">my link</a>')
+      end
+    end
+    assert measurement.total < 2, "performance was too slow, took #{measurement.total} seconds"
   end
 
 protected


### PR DESCRIPTION
This improves the performance of reusing a sanitizer (without changing its options) by about 10x.

Added a performance regression test.

Before this patch, the test took approximately 13 seconds, after it, it's less than one second.
