### PR TITLE
allow specifying the css property whitelist

### DIFF
--- a/lib/rails/html/owasp/sanitizer.rb
+++ b/lib/rails/html/owasp/sanitizer.rb
@@ -75,22 +75,29 @@ module Rails
         class << self
           attr_accessor :allowed_tags
           attr_accessor :allowed_attributes
+          attr_accessor :allowed_css_properties
         end
 
-        def sanitize_css(style_string)
-          styling_policy.sanitize_css_properties(style_string).to_s
+        def sanitize_css(style_string, options = {})
+          options = options_with_defaults(options)
+          styling_policy(options).sanitize_css_properties(style_string).to_s
         end
 
         private
 
-        def policy(options = {})
-          options = {
+        def options_with_defaults(options)
+          {
             tags: (self.class.allowed_tags || Whitelist::ALLOWED_ELEMENTS),
             attributes: (self.class.allowed_attributes || Whitelist::ALLOWED_ATTRIBUTES),
+            css_properties: (self.class.allowed_css_properties || Whitelist::ALLOWED_CSS_PROPERTIES),
             add_rel_nofollow: false,
             skip_empty_tags_if_useless: false,
             allow_styling: true
           }.merge options
+        end
+
+        def policy(options = {})
+          options = options_with_defaults(options)
 
           raise ArgumentError, 'tags must be enumerable' unless Enumerable === options[:tags]
           raise ArgumentError, 'attributes must be enumerable' unless Enumerable === options[:attributes]
@@ -100,19 +107,26 @@ module Rails
             allow_attributes( *options[:attributes] ).globally.
             allow_standard_url_protocols.
             tap do |policy|
-              policy.allow_styling if options[:allow_styling]
+              if options[:allow_styling]
+                policy.allow_styling(css_schema(options[:css_properties]))
+              end
               policy.allow_without_attributes( *HtmlPolicyBuilder::DEFAULT_SKIP_IF_EMPTY ) unless options[:skip_empty_tags_if_useless]
               policy.require_rel_nofollow if options[:add_rel_nofollow]
             end
         end
 
-        def styling_policy
+        def css_schema(whitelist)
+          Java::OrgOwaspHtml::CssSchema.with_properties(whitelist.to_a)
+        end
+
+        def styling_policy(options)
           # break some privacy to get hold of a StylingPolicy instance
           constructor = Java::OrgOwaspHtml::StylingPolicy.
             java_class.declared_constructors.first
           constructor.accessible = true
-          constructor.new_instance(Java::OrgOwaspHtml::CssSchema::DEFAULT).to_java
+          constructor.new_instance(css_schema(options[:css_properties])).to_java
         end
+
       end
 
       # a WhiteListSanitizer, but without allowing links

--- a/lib/rails/html/owasp/whitelist.rb
+++ b/lib/rails/html/owasp/whitelist.rb
@@ -46,7 +46,7 @@ module Rails
       #
       # </html5_license>
       #
-      # Except ALLOWED_ELEMENTS and ALLOWED_ATTRIBUTES (which are used as
+      # Except ALLOWED_ELEMENTS, ALLOWED_CSS_PROPERTIES, and ALLOWED_ATTRIBUTES (which are used as
       # defaults for the WhiteListSanitizer) all constants here are left in
       # here for informational purposes / creating your own custom sanitizers
       # only.

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -361,7 +361,7 @@ class SanitizersTest < Minitest::Test
 
   def test_should_sanitize_illegal_style_properties
     raw      = %(display:block; position:absolute; left:0; top:0; width:100%; height:100%; z-index:1; background-color:black; background-image:url(http://www.ragingplatypus.com/i/cam-full.jpg); background-x:center; background-y:center; background-repeat:repeat;)
-    expected = %(width:100%;height:100%;background-color:black;background-repeat:repeat)
+    expected = "display:block;width:100%;height:100%;background-color:black"
     assert_equal expected, sanitize_css(raw)
   end
 


### PR DESCRIPTION
Allows subclasses and callers to override the css property whitelist, and drives it from the HTML5 whitelist by default.
